### PR TITLE
Fix bug in card deal boundary

### DIFF
--- a/Poker/Implementation/PokerDeck.cs
+++ b/Poker/Implementation/PokerDeck.cs
@@ -10,7 +10,7 @@ namespace Poker.Implementation
       while (true)
       {
         var deal = new Deal();
-        if (CurrentCard + 5 < CardDeck.Length)
+        if (CurrentCard + 5 <= CardDeck.Length)
         {
           for (var i = 0; i < 5; i++)
           {


### PR DESCRIPTION
## Summary
- fix off-by-one error when checking remaining cards in `PokerDeck.DealCard`

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae0013b50832892ba5ad5c993f47e